### PR TITLE
Backend Endpoint Interceptors and Updater

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
@@ -6,12 +6,12 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
+// import org.springframework.web.servlet.ModelAndView;
 
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
@@ -48,13 +48,13 @@ public class RoleUserInterceptor implements HandlerInterceptor {
                 User user = optionalUser.get();
 
                 Set<GrantedAuthority> newAuthorities = new HashSet<>();
-                // Collection<? extends GrantedAuthority> currentAuthorities = authentication.getAuthorities();
-                // currentAuthorities.stream()
-                // .filter(authority -> !authority.getAuthority().equals("ROLE_ADMIN")
-                // && !authority.getAuthority().equals("ROLE_INSTRUCTOR"))
-                // .forEach(authority -> {
-                //     newAuthorities.add(authority);
-                // });
+                Collection<? extends GrantedAuthority> currentAuthorities = authentication.getAuthorities();
+                currentAuthorities.stream()
+                .filter(authority -> !authority.getAuthority().equals("ROLE_ADMIN")
+                && !authority.getAuthority().equals("ROLE_INSTRUCTOR"))
+                .forEach(authority -> {
+                    newAuthorities.add(authority);
+                });
 
                 if (user.isAdmin() ){
                     newAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
@@ -1,0 +1,75 @@
+package edu.ucsb.cs156.organic.Interceptors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collection;
+import edu.ucsb.cs156.organic.entities.User;
+
+
+@Component
+public class RoleUserInterceptor implements HandlerInterceptor {
+
+   @Autowired
+   UserRepository userRepository;
+
+   @Override
+   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // Update user's security context on server each time the user makes HTTP request to the backend
+        // If user has admin status in database we will keep ROLE_ADMIN in security context
+        // Otherwise interceptor will remove ROLE_ADMIN before the incoming request is processed by backend API
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Authentication authentication = securityContext.getAuthentication();
+
+        if (authentication instanceof OAuth2AuthenticationToken ) {
+            OAuth2User oAuthUser = ((OAuth2AuthenticationToken) authentication).getPrincipal();
+            Integer githubID = oAuthUser.getAttribute("githubId");
+            Optional<User> optionalUser = userRepository.findByGithubId(githubID);
+            if (optionalUser.isPresent()){
+                User user = optionalUser.get();
+
+                Set<GrantedAuthority> newAuthorities = new HashSet<>();
+                Collection<? extends GrantedAuthority> currentAuthorities = authentication.getAuthorities();
+                currentAuthorities.stream()
+                .filter(authority -> !authority.getAuthority().equals("ROLE_ADMIN")
+                 && !authority.getAuthority().equals("ROLE_INSTRUCTOR"))
+                .forEach(authority -> {
+                    newAuthorities.add(authority);
+                });
+
+                if (user.isAdmin()){
+                    newAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+                }
+
+                if (user.isInstructor()){
+                    newAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
+                }
+                
+                Authentication newAuth = new OAuth2AuthenticationToken(oAuthUser, newAuthorities,(((OAuth2AuthenticationToken)authentication).getAuthorizedClientRegistrationId()));
+                SecurityContextHolder.getContext().setAuthentication(newAuth);
+            }
+        }
+
+      return true;
+   }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
@@ -6,12 +6,12 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-// import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.ModelAndView;
 
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -48,15 +48,15 @@ public class RoleUserInterceptor implements HandlerInterceptor {
                 User user = optionalUser.get();
 
                 Set<GrantedAuthority> newAuthorities = new HashSet<>();
-                Collection<? extends GrantedAuthority> currentAuthorities = authentication.getAuthorities();
-                currentAuthorities.stream()
-                .filter(authority -> !authority.getAuthority().equals("ROLE_ADMIN")
-                 && !authority.getAuthority().equals("ROLE_INSTRUCTOR"))
-                .forEach(authority -> {
-                    newAuthorities.add(authority);
-                });
+                // Collection<? extends GrantedAuthority> currentAuthorities = authentication.getAuthorities();
+                // currentAuthorities.stream()
+                // .filter(authority -> !authority.getAuthority().equals("ROLE_ADMIN")
+                // && !authority.getAuthority().equals("ROLE_INSTRUCTOR"))
+                // .forEach(authority -> {
+                //     newAuthorities.add(authority);
+                // });
 
-                if (user.isAdmin()){
+                if (user.isAdmin() ){
                     newAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 }
 

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
@@ -42,7 +42,7 @@ public class RoleUserInterceptor implements HandlerInterceptor {
 
         if (authentication instanceof OAuth2AuthenticationToken ) {
             OAuth2User oAuthUser = ((OAuth2AuthenticationToken) authentication).getPrincipal();
-            Integer githubID = oAuthUser.getAttribute("githubId");
+            Integer githubID = oAuthUser.getAttribute("id");
             Optional<User> optionalUser = userRepository.findByGithubId(githubID);
             if (optionalUser.isPresent()){
                 User user = optionalUser.get();

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorAppConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorAppConfig.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.organic.Interceptors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Component
+public class RoleUserInterceptorAppConfig implements WebMvcConfigurer {
+   @Autowired
+   RoleUserInterceptor roleUserInterceptor;
+
+   @Override
+   public void addInterceptors(InterceptorRegistry registry) {
+      registry.addInterceptor(roleUserInterceptor);
+   }
+   
+}

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorAppConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorAppConfig.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.organic.Interceptors;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
+// import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorAppConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorAppConfig.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.organic.Interceptors;
 
 import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
@@ -95,8 +95,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
           }
           
-          boolean userIsInstructor=getInstructor(githubLogin);
-          if (userIsInstructor){
+          if (getInstructor(githubLogin)){
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
           }
         }

--- a/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
           }
           
-          boolean userIsInstructor=updateInstructor(githubLogin);
+          boolean userIsInstructor=getInstructor(githubLogin);
           if (userIsInstructor){
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
           }
@@ -120,7 +120,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     return result;
   }
 
-  public boolean updateInstructor(String githubLogin) {
+  public boolean getInstructor(String githubLogin) {
     Optional<User> u = userRepository.findByGithubLogin(githubLogin);
     return u.isPresent() && u.get().isInstructor();
   }

--- a/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
@@ -94,6 +94,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           if (userIsAdmin) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
           }
+          
           boolean userIsInstructor=updateInstructor(githubLogin);
           if (userIsInstructor){
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
@@ -120,16 +121,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   }
 
   public boolean updateInstructor(String githubLogin) {
-    if (adminGithubLogins.contains(githubLogin)) {
-      return true;
-    }
     Optional<User> u = userRepository.findByGithubLogin(githubLogin);
-    boolean result = u.isPresent() && u.get().isInstructor();
-    if (result) {
-      User user = u.get();
-      user.setInstructor(true);
-      userRepository.save(user);
-    }
-    return result;
+    return u.isPresent() && u.get().isInstructor();
   }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
@@ -94,6 +94,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           if (userIsAdmin) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
           }
+          boolean userIsInstructor=updateInstructor(githubLogin);
+          if (userIsInstructor){
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
+          }
         }
 
       });
@@ -110,6 +114,20 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     if (result) {
       User user = u.get();
       user.setAdmin(true);
+      userRepository.save(user);
+    }
+    return result;
+  }
+
+  public boolean updateInstructor(String githubLogin) {
+    if (adminGithubLogins.contains(githubLogin)) {
+      return true;
+    }
+    Optional<User> u = userRepository.findByGithubLogin(githubLogin);
+    boolean result = u.isPresent() && u.get().isInstructor();
+    if (result) {
+      User user = u.get();
+      user.setInstructor(true);
       userRepository.save(user);
     }
     return result;

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -69,43 +69,6 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
     }
 
     @Test
-    public void interceptor_no_change_when_all_fields_are_correct() throws Exception {
-        // Set up
-        User mockUser = User.builder()
-            .email("tommy@ucsb.edu")
-            .githubId(123456)
-            .githubLogin("tommy602")
-            .fullName("Thomas Tommot")
-            .emailVerified(true)
-            .admin(true)
-            .instructor(true)
-            .build();
-        when(userRepository.findByGithubId(123456)).thenReturn(Optional.of(mockUser));
-
-        // Act
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
-        HandlerExecutionChain chain = mapping.getHandler(request);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        assert chain != null;
-        Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
-                        .stream()
-                        .filter(RoleUserInterceptor.class::isInstance)
-                        .findAny();
-
-        assertTrue(roleRuleInterceptor.isPresent());
-        roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
-
-        // Assert
-        Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
-        verify(userRepository, times(1)).findByGithubId(123456);
-        boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
-        boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_INSTRUCTOR"));
-        assertTrue(hasAdminRole, "ROLE_ADMIN should exist in authorities");
-        assertTrue(hasInstructorRole, "ROLE_INSTRUCTOR should exist from authorities");
-    }
-
-    @Test
     public void user_not_present_in_db_and_no_role_update_by_interceptor() throws Exception {
          // Set up
          User mockUser = User.builder()

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -53,6 +53,8 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         attributes.put("githubId", 123456);
         attributes.put("email", "tommy@ucsb.edu");
         attributes.put("githubLogin", "tommy602");
+        attributes.put("fullName", "Thomas Tommot");
+        attributes.put("emailVerified", true);
 
         Set<GrantedAuthority> fakeAuthorities = new HashSet<>();
         fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
@@ -73,6 +75,8 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
          .email("cgaucho@ucsb.edu")
          .githubId(654321)
          .githubLogin("erica875")
+         .fullName("Erica Ricae")
+         .emailVerified(true)
          .admin(false)
          .instructor(true)
          .build();
@@ -108,6 +112,8 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
             .email("tommy@ucsb.edu")
             .githubId(123456)
             .githubLogin("tommy602")
+            .fullName("Thomas Tommot")
+            .emailVerified(true)
             .admin(false)
             .instructor(true)
             .build();
@@ -137,12 +143,14 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
     }
 
     @Test
-    public void interceptor_removes_driver_role_when_driver_field_in_db_is_false() throws Exception {
+    public void interceptor_removes_instructor_role_when_driver_field_in_db_is_false() throws Exception {
         // Set up
         User mockUser = User.builder()
             .email("tommy@ucsb.edu")
             .githubId(123456)
             .githubLogin("tommy602")
+            .fullName("Thomas Tommot")
+            .emailVerified(true)
             .admin(true)
             .instructor(false)
             .build();

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -69,6 +69,43 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
     }
 
     @Test
+    public void interceptor_no_change_when_all_fields_are_correct() throws Exception {
+        // Set up
+        User mockUser = User.builder()
+            .email("tommy@ucsb.edu")
+            .githubId(123456)
+            .githubLogin("tommy602")
+            .fullName("Thomas Tommot")
+            .emailVerified(true)
+            .admin(true)
+            .instructor(true)
+            .build();
+        when(userRepository.findByGithubId(123456)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                        .stream()
+                        .filter(RoleUserInterceptor.class::isInstance)
+                        .findAny();
+
+        assertTrue(roleRuleInterceptor.isPresent());
+        roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        // Assert
+        Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+        verify(userRepository, times(1)).findByGithubId(123456);
+        boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+        boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_INSTRUCTOR"));
+        assertTrue(hasAdminRole, "ROLE_ADMIN should exist in authorities");
+        assertTrue(hasInstructorRole, "ROLE_INSTRUCTOR should exist from authorities");
+    }
+
+    @Test
     public void user_not_present_in_db_and_no_role_update_by_interceptor() throws Exception {
          // Set up
          User mockUser = User.builder()

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -50,7 +50,7 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
     @BeforeEach
     public void setupSecurityContext(){
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put("githubId", 123456);
+        attributes.put("id", 123456);
         attributes.put("email", "tommy@ucsb.edu");
         attributes.put("githubLogin", "tommy602");
         attributes.put("fullName", "Thomas Tommot");

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -1,0 +1,166 @@
+package edu.ucsb.cs156.organic.Interceptors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.security.core.context.SecurityContext;
+import  org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.controllers.ControllerTestCase;
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.Optional;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RoleUserInterceptorTests extends ControllerTestCase{
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    private RequestMappingHandlerMapping mapping;
+
+    @BeforeEach
+    public void setupSecurityContext(){
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("githubId", 123456);
+        attributes.put("email", "mockOauth@gmail.com");
+
+        Set<GrantedAuthority> fakeAuthorities = new HashSet<>();
+        fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
+
+        OAuth2User mockUser = new DefaultOAuth2User(fakeAuthorities, attributes, "githubLogin");
+        Authentication authentication = new OAuth2AuthenticationToken(mockUser, fakeAuthorities , "mockUserRegisterId");
+        // Set up some mock oauth authentication in the SecurityContextHolder for test environment
+        // Be aware: SecurityContext is thread bound
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    public void user_not_present_in_db_and_no_role_update_by_interceptor() throws Exception {
+         // Set up
+         User mockUser = User.builder()
+         .email("cgaucho@ucsb.edu")
+         .githubId(654321)
+         .admin(false)
+         .build();
+        when(userRepository.findByGithubId(654321)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                        .stream()
+                        .filter(RoleUserInterceptor.class::isInstance)
+                        .findAny();
+
+        assertTrue(roleRuleInterceptor.isPresent());
+        roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        // Assert
+        Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+        verify(userRepository, times(1)).findByGithubId(123456);
+        boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+        boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_INSTRUCTOR"));
+        assertTrue(hasAdminRole, "ROLE_ADMIN should exist authorities");
+        assertTrue(hasInstructorRole, "ROLE_INSTRUCTOR should exist in authorities");
+    }
+
+    @Test
+    public void interceptor_removes_admin_role_when_admin_field_in_db_is_false() throws Exception {
+        // Set up
+        User mockUser = User.builder()
+            .email("cgaucho@ucsb.edu")
+            .githubId(123456)
+            .admin(false)
+            .build();
+        when(userRepository.findByGithubId(123456)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                        .stream()
+                        .filter(RoleUserInterceptor.class::isInstance)
+                        .findAny();
+
+        assertTrue(roleRuleInterceptor.isPresent());
+        roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        // Assert
+        Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+        verify(userRepository, times(1)).findByGithubId(123456);
+        boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+        boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_DRIVER"));
+        assertFalse(hasAdminRole, "ROLE_ADMIN should be removed from authorities");
+        assertTrue(hasInstructorRole, "ROLE_INSTRUCTOR should exist in authorities");
+    }
+
+    @Test
+    public void interceptor_removes_driver_role_when_driver_field_in_db_is_false() throws Exception {
+        // Set up
+        User mockUser = User.builder()
+            .email("cgaucho@ucsb.edu")
+            .githubId(123456)
+            .admin(true)
+            .build();
+        when(userRepository.findByGithubId(123456)).thenReturn(Optional.of(mockUser));
+
+        // Act
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                        .stream()
+                        .filter(RoleUserInterceptor.class::isInstance)
+                        .findAny();
+
+        assertTrue(roleRuleInterceptor.isPresent());
+        roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        // Assert
+        Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+        verify(userRepository, times(1)).findByGithubId(123456);
+        boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+        boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_DRIVER"));
+        assertTrue(hasAdminRole, "ROLE_ADMIN should exist in authorities");
+        assertFalse(hasInstructorRole, "ROLE_INSTRUCTOR should be removed from authorities");
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -59,6 +59,7 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         Set<GrantedAuthority> fakeAuthorities = new HashSet<>();
         fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
         fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_INSTRUCTOR"));
+        fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
 
         OAuth2User mockUser = new DefaultOAuth2User(fakeAuthorities, attributes, "githubLogin");
         Authentication authentication = new OAuth2AuthenticationToken(mockUser, fakeAuthorities , "mockUserRegisterId");
@@ -101,8 +102,10 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         verify(userRepository, times(1)).findByGithubId(123456);
         boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
         boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_INSTRUCTOR"));
+        boolean hasUSERRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_USER"));
         assertTrue(hasAdminRole, "ROLE_ADMIN should exist authorities");
         assertTrue(hasInstructorRole, "ROLE_INSTRUCTOR should exist in authorities");
+        assertTrue(hasUSERRole, "ROLE_USER should exist in authorities");
     }
 
     @Test
@@ -138,8 +141,10 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         verify(userRepository, times(1)).findByGithubId(123456);
         boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
         boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_INSTRUCTOR"));
+        boolean hasUSERRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_USER"));
         assertFalse(hasAdminRole, "ROLE_ADMIN should be removed from authorities");
         assertTrue(hasInstructorRole, "ROLE_INSTRUCTOR should exist in authorities");
+        assertTrue(hasUSERRole, "ROLE_USER should exist in authorities");
     }
 
     @Test
@@ -175,7 +180,9 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         verify(userRepository, times(1)).findByGithubId(123456);
         boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
         boolean hasInstructorRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_INSTRUCTOR"));
+        boolean hasUSERRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_USER"));
         assertTrue(hasAdminRole, "ROLE_ADMIN should exist in authorities");
         assertFalse(hasInstructorRole, "ROLE_INSTRUCTOR should be removed from authorities");
+        assertTrue(hasUSERRole, "ROLE_USER should exist in authorities");
     }
 }

--- a/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptorTests.java
@@ -72,6 +72,7 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
          User mockUser = User.builder()
          .email("cgaucho@ucsb.edu")
          .githubId(654321)
+         .githubLogin("erica875")
          .admin(false)
          .instructor(true)
          .build();
@@ -106,6 +107,7 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         User mockUser = User.builder()
             .email("tommy@ucsb.edu")
             .githubId(123456)
+            .githubLogin("tommy602")
             .admin(false)
             .instructor(true)
             .build();
@@ -140,6 +142,7 @@ public class RoleUserInterceptorTests extends ControllerTestCase{
         User mockUser = User.builder()
             .email("tommy@ucsb.edu")
             .githubId(123456)
+            .githubLogin("tommy602")
             .admin(true)
             .instructor(false)
             .build();

--- a/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
@@ -23,7 +23,7 @@ import liquibase.pro.packaged.em;
 import static org.mockito.Mockito.when;
 
 @Slf4j
-@Service("currentUser")
+@Service("currentUserMock")
 public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
 
   public User getMockUser(SecurityContext securityContext, Authentication authentication) {


### PR DESCRIPTION
**No dependencies, merge first**
- added interceptors to ensure admin and instructor roles are updated properly
- added code to add role_instructor
- Implemented tests for Interceptors
- modified MockCurrentUserServiceImpl.java to change service class name to currentUserMock instead of currentUser
- uncommented code to account for ROLE_USER. The lambda expression might not be necessary if every user is guranteed to have ROLE_USER, as you can just port it over without checking.
- Toggle works, if you toggle either instructor or admin, the change will reflect in get all users as well as user profile
- Addressed error (2) and (3)

Deployed at: https://po-whuang602.dokku-06.cs.ucsb.edu


close #5 