### PR TITLE
Web metadata change

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Deployments
 
 | Type | Link       | 
+|------|------------|
 | prod | <https://po-prod.dokku-06.cs.ucsb.edu/>     | 
 | qa   | <https://organic-qa.dokku-06.cs.ucsb.edu/>  | 
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>CS156 Project Organic</title>
+    <title>Organic</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="UCSB CS156 Project Organic"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Organic</title>
+    <title>CS156 Project Organic</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
**Merge #48 first**

- changed the website's metadata from default "web site created with create-react-app" to "UCSB CS156 Project Organic"
This can be tested whenever you paste the link somewhere (especially on slack), it will now give the viewer an accurate description of what the app actually is.
![Screenshot 2023-11-28 223253](https://github.com/ucsb-cs156-f23/proj-organic-f23-6pm-2/assets/72839223/6b80131b-f1f0-4cdf-8bb6-74b19a81318a)

close #44 