### PR TITLE
Fix courses api endpoints by fixing "end" postgres keyword conflict

### DIFF
--- a/frontend/src/fixtures/coursesFixtures.js
+++ b/frontend/src/fixtures/coursesFixtures.js
@@ -4,8 +4,8 @@ const coursesFixtures = {
         "name": "course1",
         "school": "school1",
         "term": "term1",
-        "start": "2023-01-01T12:00:00",
-        "end": "2023-05-05T12:00:00",
+        "startDate": "2023-01-01T12:00:00",
+        "endDate": "2023-05-05T12:00:00",
         "githubOrg": "org1"
     },
     threeCourses: [
@@ -14,8 +14,8 @@ const coursesFixtures = {
             "name": "course2",
             "school": "school2",
             "term": "term2",
-            "start": "2023-02-02T12:00:00",
-            "end": "2023-06-06T12:00:00",
+            "startDate": "2023-02-02T12:00:00",
+            "endDate": "2023-06-06T12:00:00",
             "githubOrg": "org2"
         },
         {
@@ -23,8 +23,8 @@ const coursesFixtures = {
             "name": "course3",
             "school": "school3",
             "term": "term3",
-            "start": "2023-03-03T12:00:00",
-            "end": "2023-07-07T12:00:00",
+            "startDate": "2023-03-03T12:00:00",
+            "endDate": "2023-07-07T12:00:00",
             "githubOrg": "org3"
         },
         {
@@ -32,8 +32,8 @@ const coursesFixtures = {
             "name": "course4",
             "school": "school4",
             "term": "term4",
-            "start": "2023-04-04T12:00:00",
-            "end": "2023-08-08T12:00:00",
+            "startDate": "2023-04-04T12:00:00",
+            "endDate": "2023-08-08T12:00:00",
             "githubOrg": "org4"
         }
     ]

--- a/frontend/src/main/components/Courses/CoursesForm.js
+++ b/frontend/src/main/components/Courses/CoursesForm.js
@@ -90,30 +90,30 @@ function CoursesForm({ initialContents, submitAction, buttonLabel = "Create" }) 
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="start">Start Date (iso format)</Form.Label>
+                <Form.Label htmlFor="startDate">Start Date (iso format)</Form.Label>
                 <Form.Control
-                    data-testid={testIdPrefix + "-start"}
-                    id="start"
+                    data-testid={testIdPrefix + "-startDate"}
+                    id="startDate"
                     type="datetime-local"
-                    isInvalid={Boolean(errors.start)}
-                    {...register("start", { required: true, pattern: isodate_regex })}
+                    isInvalid={Boolean(errors.startDate)}
+                    {...register("startDate", { required: true, pattern: isodate_regex })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.start && 'Start Date is required.'}
+                    {errors.startDate && 'Start Date is required.'}
                 </Form.Control.Feedback>
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="end">End Date (iso format)</Form.Label>
+                <Form.Label htmlFor="endDate">End Date (iso format)</Form.Label>
                 <Form.Control
-                    data-testid={testIdPrefix + "-end"}
-                    id="end"
+                    data-testid={testIdPrefix + "-endDate"}
+                    id="endDate"
                     type="datetime-local"
-                    isInvalid={Boolean(errors.end)}
-                    {...register("end", { required: true, pattern: isodate_regex })}
+                    isInvalid={Boolean(errors.endDate)}
+                    {...register("endDate", { required: true, pattern: isodate_regex })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.end && 'End Date is required.'}
+                    {errors.endDate && 'End Date is required.'}
                 </Form.Control.Feedback>
             </Form.Group>
 

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -49,11 +49,11 @@ export default function CoursesTable({
         },
         {
             Header: 'Start Date (iso format)',
-            accessor: 'start',
+            accessor: 'startDate',
         },
         {
             Header: 'End Date (iso format)',
-            accessor: 'end',
+            accessor: 'endDate',
         },
         {
             Header: 'GitHub Org',

--- a/frontend/src/tests/components/Courses/CoursesForm.test.js
+++ b/frontend/src/tests/components/Courses/CoursesForm.test.js
@@ -78,23 +78,23 @@ describe("CoursesForm tests", () => {
         const nameField = screen.getByTestId("CoursesForm-name");
         const schoolField = screen.getByTestId("CoursesForm-school");
         const termField = screen.getByTestId("CoursesForm-term");
-        const startField = screen.getByTestId("CoursesForm-start");
-        const endField = screen.getByTestId("CoursesForm-end");
+        const startDateField = screen.getByTestId("CoursesForm-startDate");
+        const endDateField = screen.getByTestId("CoursesForm-endDate");
         const githubOrgField = screen.getByTestId("CoursesForm-githubOrg");
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'course1' } });
         fireEvent.change(schoolField, { target: { value: 'school1' } });
         fireEvent.change(termField, { target: { value: 'term1' } });
-        fireEvent.change(startField, { target: { value: '2023-01-01T12:00:00' } });
-        fireEvent.change(endField, { target: { value: '2023-05-05T12:00:00' } });
+        fireEvent.change(startDateField, { target: { value: '2023-01-01T12:00:00' } });
+        fireEvent.change(endDateField, { target: { value: '2023-05-05T12:00:00' } });
         fireEvent.change(githubOrgField, { target: { value: 'org1' } });
         fireEvent.click(submitButton);
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(screen.queryByText(/start must be in ISO format/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/end must be in ISO format/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/startDate must be in ISO format/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/endDate must be in ISO format/)).not.toBeInTheDocument();
 
     });
 

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -17,7 +17,7 @@ describe("CoursesTable tests", () => {
   const queryClient = new QueryClient();
 
   const expectedHeaders = ["id", "Name", "School", "Term", "Start Date (iso format)", "End Date (iso format)", "GitHub Org"];
-  const expectedFields = ["id", "name", "school", "term", "start", "end", "githubOrg"];
+  const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
   const testId = "CoursesTable";
 
   test("renders empty table correctly", () => {

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -63,8 +63,8 @@ public class CoursesController extends ApiController {
             @Parameter(name = "name", description ="course name, e.g. CMPSC 156" ) @RequestParam String name,
             @Parameter(name = "school", description ="school abbreviation e.g. UCSB" ) @RequestParam String school,
             @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
-            @Parameter(name = "start", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @Parameter(name = "end", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @Parameter(name = "startDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(name = "endDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @Parameter(name = "githubOrg", description = "for example ucsb-cs156-f23" ) @RequestParam String githubOrg)
             throws JsonProcessingException {
 
@@ -72,8 +72,8 @@ public class CoursesController extends ApiController {
                 .name(name)
                 .school(school)
                 .term(term)
-                .start(start)
-                .end(end)
+                .startDate(startDate)
+                .endDate(endDate)
                 .githubOrg(githubOrg)
                 .build();
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -133,8 +133,8 @@ public class CoursesController extends ApiController {
         course.setName(incoming.getName());
         course.setSchool(incoming.getSchool());
         course.setTerm(incoming.getTerm());
-        course.setStart(incoming.getStart());
-        course.setEnd(incoming.getEnd());
+        course.setStartDate(incoming.getStartDate());
+        course.setEndDate(incoming.getEndDate());
         course.setGithubOrg(incoming.getGithubOrg());
         if(user.isAdmin()) {
                 courseRepository.save(course);

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
@@ -19,7 +19,7 @@ public class Course {
   private String name;
   private String school;
   private String term;
-  private LocalDateTime start;
-  private LocalDateTime end;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
   private String githubOrg;
 }

--- a/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
+++ b/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
@@ -34,7 +34,7 @@
               },
               {
                 "column": {
-                  "name": "END",
+                  "name": "END_DATE",
                   "type": "TIMESTAMP"
                 }
               },
@@ -58,7 +58,7 @@
               },
               {
                 "column": {
-                  "name": "START",
+                  "name": "START_DATE",
                   "type": "TIMESTAMP"
                 }
               },

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -80,8 +80,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                         .name("CS156")
                         .school("UCSB")
                         .term("F23")
-                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                         .githubOrg("ucsb-cs156-f23")
                         .build();
 
@@ -90,8 +90,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                         .name("CS148")
                         .school("UCSB")
                         .term("S24")
-                        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-                        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
                         .githubOrg("ucsb-cs148-w24")
                         .build();
 
@@ -150,8 +150,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -160,8 +160,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -169,7 +169,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/courses/post?name=CS16&school=UCSB&term=F23&start=2023-09-01T00:00:00&end=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                                post("/api/courses/post?name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -200,8 +200,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS123")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-02T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-30T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-02T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-30T00:00:00"))
                                 .githubOrg("ucsb-cs123-f23")
                                 .build();
 
@@ -210,8 +210,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS124")
                                 .school("UCSBSB")
                                 .term("W24")
-                                .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-                                .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
                                 .githubOrg("ucsb-cs123-w24")
                                 .build();
 
@@ -258,8 +258,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -268,8 +268,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS24")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs24-f23")
                                 .build();
                 
@@ -312,8 +312,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -322,8 +322,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS24")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs24-f23")
                                 .build();
 
@@ -355,8 +355,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS24")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs24-f23")
                                 .build();
 
@@ -389,8 +389,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 
@@ -432,8 +432,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                         .name("CS16")
                         .school("UCSB")
                         .term("F23")
-                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                         .githubOrg("ucsb-cs16-f23")
                         .build();
                 
@@ -470,8 +470,8 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .name("CS16")
                                 .school("UCSB")
                                 .term("F23")
-                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                                 .githubOrg("ucsb-cs16-f23")
                                 .build();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
@@ -89,8 +89,8 @@ public class StudentsControllerTests extends ControllerTestCase {
                         .name("CS156")
                         .school("UCSB")
                         .term("F23")
-                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                         .githubOrg("ucsb-cs156-f23")
                         .build();
 
@@ -99,8 +99,8 @@ public class StudentsControllerTests extends ControllerTestCase {
                         .name("CS148")
                         .school("UCSB")
                         .term("S24")
-                        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-                        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                        .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                        .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
                         .githubOrg("ucsb-cs148-w24")
                         .build();
 

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UserInfoControllerTests.java
@@ -126,8 +126,8 @@ public class UserInfoControllerTests extends ControllerTestCase {
         .name("CS156")
         .school("UCSB")
         .term("F23")
-        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
-        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+        .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
+        .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
         .githubOrg("ucsb-cs156-f23")
         .build();
 
@@ -136,8 +136,8 @@ public class UserInfoControllerTests extends ControllerTestCase {
         .name("CS148")
         .school("UCSB")
         .term("S24")
-        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
-        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+        .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+        .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
         .githubOrg("ucsb-cs148-w24")
         .build();
 


### PR DESCRIPTION
- Changed all instances of start and end to startDate and endDate
- Restarted database

Dokku deployment: https://oj-dev.dokku-06.cs.ucsb.edu/

To test: run Courses endpoints in Swagger at https://oj-dev.dokku-06.cs.ucsb.edu/swagger-ui/index.html

Closes #60